### PR TITLE
Fix UnicodeEncodeError: 'charmap' codec can't encode character in Pyt…

### DIFF
--- a/unwebpack_sourcemap.py
+++ b/unwebpack_sourcemap.py
@@ -148,7 +148,7 @@ class SourceMapExtractor(object):
         map_data = ""
         if is_str is False:
             if os.path.isfile(target):
-                with open(target, 'r') as f:
+                with open(target, 'r', encoding='utf-8', errors='ignore') as f:
                     map_data = f.read()
         else:
             map_data = target
@@ -181,7 +181,7 @@ class SourceMapExtractor(object):
                 write_path = self._get_sanitised_file_path(source)
                 if write_path is not None:
                     os.makedirs(os.path.dirname(write_path), mode=0o755, exist_ok=True)
-                    with open(write_path, 'w') as f:
+                    with open(write_path, 'w', encoding='utf-8', errors='ignore') as f:
                         print("Writing %s..." % os.path.basename(write_path))
                         f.write(content)
             else:


### PR DESCRIPTION
Fixed this error when running in Python3

```
Traceback (most recent call last):
  File "unwebpack_sourcemap.py", line 350, in <module>
    extractor.run()
  File "unwebpack_sourcemap.py", line 67, in run
    self._parse_remote_sourcemap(sourcemap)
  File "unwebpack_sourcemap.py", line 95, in _parse_remote_sourcemap
    self._parse_sourcemap(data, True)
  File "unwebpack_sourcemap.py", line 186, in _parse_sourcemap
    f.write(content)
  File "C:\Users\aguss\AppData\Local\Programs\Python\Python38-32\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u21e7' in position 178521: character maps to <undefined>
```