### PR TITLE
Do not crash on empty content

### DIFF
--- a/unwebpack_sourcemap.py
+++ b/unwebpack_sourcemap.py
@@ -47,10 +47,10 @@ class SourceMapExtractor(object):
                     raise SourceMapExtractorError("output_directory does not exist. Pass --make-directory to auto-make it.")
 
         self._path_sanitiser = PathSanitiser(self._output_directory)
-        
+
         if options['disable_ssl_verification'] == True:
             self.disable_verify_ssl = True
-            
+
         if options['local'] == True:
             self._is_local = True
 
@@ -177,6 +177,8 @@ class SourceMapExtractor(object):
                 path = source
                 content = map_object['sourcesContent'][idx]
                 idx += 1
+                if content is None:
+                    continue
 
                 # remove webpack:// from paths
                 # and do some checks on it


### PR DESCRIPTION
Fix for this error I was having

```
Traceback (most recent call last):
  File "/.../unwebpack-sourcemap/unwebpack_sourcemap.py", line 362, in <module>
    extractor.run()
  File "/.../unwebpack-sourcemap/unwebpack_sourcemap.py", line 74, in run
    self._parse_sourcemap(self._target)
  File "/.../unwebpack-sourcemap/unwebpack_sourcemap.py", line 188, in _parse_sourcemap
    f.write(content)
TypeError: write() argument must be str, not None
```